### PR TITLE
Linux build fixes

### DIFF
--- a/cl_fluid_sim.h
+++ b/cl_fluid_sim.h
@@ -6,12 +6,13 @@
 #include <math.h>
 
 #ifdef __APPLE__
-  #include "OpenCL/opencl.h"
-  #include "OpenGL/gl.h"
-  #include "OpenGL/opengl.h"
-#elif __linux__
-  #include "CL/cl.h"
-  #include "GL/gl.h"
+  #include <OpenCL/opencl.h>
+  #include <OpenGL/gl.h>
+  #include <OpenGL/opengl.h>
+#else
+  #include <CL/cl.h>
+  #include <GL/gl.h>
+  #include <GL/glut.h>
 #endif
 
 #define KB 1024

--- a/sdl_window.h
+++ b/sdl_window.h
@@ -3,12 +3,8 @@
 
 #include <stdio.h>
 
-#ifdef __APPLE__
-  #include "SDL2/SDL.h"
-  #include "SDL2/SDL_opengl.h"
-#elif __linux__
-  #include "SDL2/SDL.h"
-#endif
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_opengl.h>
 
 typedef struct window_t
 {


### PR DESCRIPTION
This gets your code to build on my machine. It doesn't quite work though--it crashes with a segfault here:

```
#1  0x0000555555557813 in create_fluid_sim (window_texture=1, kernel_filename=0x55555555a209 "fluid_kernel.cl", sim_size=128, 
    diff=9.99999975e-05, visc=9.99999975e-05, num_r_steps=20, flags=F_USE_GPU) at cl_fluid_sim.c:236
236	    fluid->framebuffer = clCreateFromGLTexture2D(fluid->context, CL_MEM_WRITE_ONLY, GL_TEXTURE_2D, 0, window_texture, &err);
```

But that's very likely due to [Beignet](https://01.org/beignet) not support GL interop.